### PR TITLE
fix es_manage command on python 3

### DIFF
--- a/simple_elasticsearch/management/commands/es_manage.py
+++ b/simple_elasticsearch/management/commands/es_manage.py
@@ -5,6 +5,11 @@ from django.core.management.base import BaseCommand, CommandError
 
 from ...utils import get_indices, create_indices, rebuild_indices
 
+try:
+    raw_input
+except NameError:
+    raw_input = input
+
 
 class Unbuffered(object):
     def __init__(self, stream):


### PR DESCRIPTION
Hi

Appologize for my poor english!


I found djang-simple-elasticsearch when I was introduce ElasticSearch.
I using this library with Python 3.4.2.

Tried `es_manage` command and I got errors.

```
python manage.py es_manage --rebuild
```

```
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/key/Documents/virtualenv/photoshare/lib/python3.4/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/Users/key/Documents/virtualenv/photoshare/lib/python3.4/site-packages/django/core/management/__init__.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/key/Documents/virtualenv/photoshare/lib/python3.4/site-packages/django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/Users/key/Documents/virtualenv/photoshare/lib/python3.4/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/Users/key/Documents/virtualenv/photoshare/lib/python3.4/site-packages/simple_elasticsearch/management/commands/es_manage.py", line 71, in handle
    self.subcommand_rebuild(requested_indexes, no_input)
  File "/Users/key/Documents/virtualenv/photoshare/lib/python3.4/site-packages/simple_elasticsearch/management/commands/es_manage.py", line 104, in subcommand_rebuild
    user_input = raw_input('Are you sure you want to rebuild {0} index(es)? [y/N]: '.format('the ' + ', '.join(indexes) if indexes else '**ALL**')).lower()
NameError: name 'raw_input' is not defined
```

Python 3 doesn't have `raw_input()`.
Use `input()` instead of `raw_input()`.
